### PR TITLE
allow for custom template variables

### DIFF
--- a/Source/simple-modal.js
+++ b/Source/simple-modal.js
@@ -246,7 +246,14 @@ var SimpleModal = new Class({
 			node = document.getElement('#simple-modal.simple-modal');		
 		
 		// Set Contents
-		var html = this._template(this.options.template, {"_TITLE_":options.title || "Untitled", "_CONTENTS_":options.contents || ""});
+		var template_vars = {"_TITLE_":options.title || "Untitled", "_CONTENTS_":options.contents || ""};
+		if (options.template_vars)
+		{
+			Object.each(options.template_vars, function(val, key){
+				template_vars[key] = val;
+			});
+		}
+		var html = this.options.template.substitute(template_vars);
 		
 		node.set("html", html);
 		
@@ -686,19 +693,8 @@ var SimpleModal = new Class({
            var fixEV = Browser.name != 'ie' ? "keydown" : "onkeydown";
            window.addEvent(fixEV, this._removeSM );
          }
-  		  }
-     },
-      
-    /**
-    * private method _template
-    * simple template by Thomas Fuchs
-    * @return
-    */
-    _template:function(s,d){
-     for(var p in d)
-       s=s.replace(new RegExp('{'+p+'}','g'), d[p]);
-     return s;
-    }
+  	   }
+     }
 });
 
 /**


### PR DESCRIPTION
- allow the user to provide additional template variables, as they may be needed when they change `options.template`. Custom template variables are provided by passing a `template_vars` dictionary to the SM init method.
- remove an unneeded `_template` function; MooTools already has that feature.
