### PR TITLE
modal confirm : btn_cancel optionnal and show another modal in callback

### DIFF
--- a/Source/simple-modal.js
+++ b/Source/simple-modal.js
@@ -115,13 +115,14 @@ var SimpleModal = new Class({
         case "confirm":			
 			// Add button confirm
 			this.addButton(this.options.btn_ok, "btn primary btn-margin", function(){
-				try{ options.callback() } catch(err){};
 				this.hide();
+				try{ options.callback() } catch(err){};
 			})
           
 			// Add button cancel
-			this.addButton(this.options.btn_cancel, "btn secondary");
-			
+			if(this.options.btn_cancel!==false){
+				this.addButton(this.options.btn_cancel, "btn secondary");
+			}
 			// Rendering
 			var node = this._drawWindow(options);
 			


### PR DESCRIPTION
Hello,

I met some difficult by using simplemodal especially with model "confirm".  For exemple: sometimes, I don't need btn_cancel in a "confirm" or I need to display another modal  in callback function. 

So I propose to you a little modif. It's may be useful.

With this modification: 
firstly, btn_cancel is optional in a  modal confirm.
secondly, you can display another modal in callback function .

Best regards,
svd
